### PR TITLE
Logica para listar todas as imagens classificadas

### DIFF
--- a/backend/src/controllers/ListImagesController.ts
+++ b/backend/src/controllers/ListImagesController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import makeListarImagens from '@/factory/makeListarImage';
+
+
+class ListImagesController {
+    public async list(req: Request, res: Response): Promise<Response> {
+        try {
+           
+            const listarImagens = makeListarImagens();
+            const imagens = await listarImagens.execute();
+            
+            return res.status(200).json(imagens);
+
+        } catch (error: any) {
+            console.error("Não foram encontradas imagens:", error.message);
+            return res.status(500).json({ error: "Erro interno ao buscar imagens." });
+        }
+    }
+}
+
+export default new ListImagesController();

--- a/backend/src/factory/makeListarImage.ts
+++ b/backend/src/factory/makeListarImage.ts
@@ -1,0 +1,10 @@
+import { ListarImageRepository } from "@/repository/ListarImagens";
+import { ListarImageUseCase } from "@/use-case/ListarImagesUseCase";
+
+
+export default function makeListarImagens(){
+    const repository = new ListarImageRepository();
+    const useCase = new ListarImageUseCase(repository);
+
+    return useCase;
+}

--- a/backend/src/repository/ListarImagens.ts
+++ b/backend/src/repository/ListarImagens.ts
@@ -1,0 +1,23 @@
+import ImagemClassificadaModel, { ImagemClassificada } from "@/models/ImagemClassificadaModel";
+
+export interface ListarImageResponse {
+  image: ImagemClassificada[];
+}
+
+
+export class ListarImageRepository {
+
+  async listarImage(): Promise<ListarImageResponse | null> {
+
+    const image: ImagemClassificada[] = await ImagemClassificadaModel.find();
+
+    if (image.length > 0) {
+      return { image }
+    }
+
+    return null
+
+
+  }
+}
+

--- a/backend/src/routes/index.routes.ts
+++ b/backend/src/routes/index.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import downloadImageRoute from "./downloadImage.routes";
+import listarImageRoute from "./listarImage.routes";
 
 export const routes = Router()
 
 routes.use("/", downloadImageRoute);
+routes.use("/", listarImageRoute)

--- a/backend/src/routes/listarImage.routes.ts
+++ b/backend/src/routes/listarImage.routes.ts
@@ -1,0 +1,11 @@
+
+import ListImagesController from '@/controllers/ListImagesController';
+import { Router } from 'express';
+
+const listarImageRoute = Router();
+
+
+// Rota para obter todas as alterações
+listarImageRoute.get('/list', ListImagesController.list);
+
+export default listarImageRoute;

--- a/backend/src/use-case/ListarImagesUseCase.ts
+++ b/backend/src/use-case/ListarImagesUseCase.ts
@@ -1,0 +1,16 @@
+import { ImagemClassificada } from "@/models/ImagemClassificadaModel";
+import { ListarImageRepository } from "@/repository/ListarImagens";
+
+
+export class ListarImageUseCase {
+  constructor(private listarImageRepository: ListarImageRepository) { }
+
+  async execute(): Promise<ImagemClassificada[] | undefined> {
+
+    const imagens = await this.listarImageRepository.listarImage();
+
+    return imagens?.image
+
+
+  }
+}


### PR DESCRIPTION
Rota: http://localhost:3010/api/list

#69 Lógica desenvolvida para atender a ISSUE 69, listar todas as imagens já classificadas e que estão salvas no mongoDB.

![image](https://github.com/user-attachments/assets/1c2f6fce-ec06-40b5-a0c0-fd083019e2cd)

